### PR TITLE
Fixed seats in 1.19.20+

### DIFF
--- a/BP/entities/seat.entity.json
+++ b/BP/entities/seat.entity.json
@@ -7,83 +7,110 @@
 			"is_summonable": true,
 			"properties": {
 				"p:seat_type": {
+					"type": "enum",
 					"values": [
-						"rustic.chair",
-						"rustic.rocking_chair",
-						"rustic.stool",
-						"rustic.sofa"
-					]
+						"rustic_chair",
+						"rustic_rocking_chair",
+						"rustic_stool",
+						"rustic_sofa"
+					],
+					"default": "rustic_chair"
 				}
 			},
 			"aliases": {
 				"furnideco:seat.rustic_chair": {
-					"p:seat_type": "rustic.chair"
+					"p:seat_type": "rustic_chair"
 				},
 				"furnideco:seat.rustic_rocking_chair": {
-					"p:seat_type": "rustic.rocking_chair"
+					"p:seat_type": "rustic_rocking_chair"
 				},
 				"furnideco:seat.rustic_stool": {
-					"p:seat_type": "rustic.stool"
+					"p:seat_type": "rustic_stool"
 				},
 				"furnideco:seat.rustic_sofa": {
-					"p:seat_type": "rustic.sofa"
+					"p:seat_type": "rustic_sofa"
 				}
 			}
 		},
+		"do_not_upgrade": {},
 		"permutations": [
 			{
-				"condition": "q.actor_property('p:seat_type') == 'rustic.chair'",
+				"condition": "q.property('p:seat_type') == 'rustic_chair'",
 				"components": {
 					"minecraft:rideable": {
 						"seat_count": 1,
-						"family_types": [ "player" ],
+						"family_types": [
+							"player"
+						],
 						"seats": [
 							{
-								"position": [ 0, -0.13, -0.15 ]
+								"position": [
+									0,
+									-0.13,
+									-0.15
+								]
 							}
 						]
 					}
 				}
 			},
 			{
-				"condition": "q.actor_property('p:seat_type') == 'rustic.rocking_chair'",
+				"condition": "q.property('p:seat_type') == 'rustic_rocking_chair'",
 				"components": {
 					"minecraft:rideable": {
 						"seat_count": 1,
-						"family_types": [ "player" ],
+						"family_types": [
+							"player"
+						],
 						"seats": [
 							{
-								"position": [ 0, -0.2, -0.12 ]
+								"position": [
+									0,
+									-0.2,
+									-0.12
+								]
 							}
 						]
 					}
 				}
 			},
 			{
-				"condition": "q.actor_property('p:seat_type') == 'rustic.stool'",
+				"condition": "q.property('p:seat_type') == 'rustic_stool'",
 				"components": {
 					"minecraft:rideable": {
 						"seat_count": 1,
-						"family_types": [ "player" ],
+						"family_types": [
+							"player"
+						],
 						"seats": [
 							{
-								"position": [ 0, -0.07, 0 ]
+								"position": [
+									0,
+									-0.07,
+									0
+								]
 							}
 						]
 					}
 				}
 			},
 			{
-				"condition": "q.actor_property('p:seat_type') == 'rustic.sofa'",
+				"condition": "q.property('p:seat_type') == 'rustic_sofa'",
 				"components": {
 					"minecraft:rideable": {
 						"seat_count": 1,
-						"family_types": [ "player" ],
+						"family_types": [
+							"player"
+						],
 						"seats": [
 							{
 								"min_rider_count": 0,
 								"max_rider_count": 1,
-								"position": [ 0, -0.25, -0.07 ]
+								"position": [
+									0,
+									-0.25,
+									-0.07
+								]
 							}
 						]
 					}
@@ -128,7 +155,10 @@
 			},
 			"minecraft:timer": {
 				"looping": false,
-				"time": [ 0, 0 ],
+				"time": [
+					0,
+					0
+				],
 				"time_down_event": {
 					"event": "e:add.rider"
 				}
@@ -157,7 +187,9 @@
 			},
 			"e:add.rider": {
 				"add": {
-					"component_groups": [ "g:detect_rider" ]
+					"component_groups": [
+						"g:detect_rider"
+					]
 				},
 				"run_command": {
 					"command": "ride @p[r=2.5] start_riding @s teleport_rider"


### PR DESCRIPTION
Mojang renamed 'actor_property' to 'property' and value 'rustic.' in 'values' array must start with an alphabetical character and otherwise have alphanumeric or underscore characters instead of a comma.